### PR TITLE
Remove utf8_encode() encode data.

### DIFF
--- a/shared/classes/class.form.php
+++ b/shared/classes/class.form.php
@@ -227,7 +227,7 @@ class Inbound_Forms {
 					}
 
 					foreach ($dropdown_fields as $key => $value) {
-						$form .= '<option value="'.$key.'">'. utf8_encode($value) .'</option>';
+						$form .= '<option value="'.$key.'">'. $value .'</option>';
 					}
 					$form .= '</select>';
 				}
@@ -907,7 +907,7 @@ class Inbound_Forms {
 			$headers = apply_filters( 'inbound_lead_notification_email_headers' , $headers );
 
 			foreach ($to_address as $key => $recipient) {
-				$result = wp_mail( $recipient , $subject , utf8_encode($body) , $headers );
+				$result = wp_mail( $recipient , $subject , $body , $headers );
 			}
 
 		} else {


### PR DESCRIPTION
My problem: When send mail, character display incorrect.

![https://trello-attachments.s3.amazonaws.com/53a986f4f819aa482992f6af/53b442c3e8d0032a92783807/661x540/785720ea8a614505a08b5ab457b30ba6/upload_2014-07-03_at_1.16.44_am.png](https://trello-attachments.s3.amazonaws.com/53a986f4f819aa482992f6af/53b442c3e8d0032a92783807/661x540/785720ea8a614505a08b5ab457b30ba6/upload_2014-07-03_at_1.16.44_am.png)

I think don't need use utf8_encode() encode $body send mail and option value.

Sr my english ^^.
