### PR TITLE
Use the existing database connection for escaping.

### DIFF
--- a/modules/module.ajax-setup.php
+++ b/modules/module.ajax-setup.php
@@ -52,11 +52,11 @@ function inbound_get_all_lead_data() {
 	if (isset($wp_lead_id) && is_numeric($wp_lead_id)) {
 		global $wpdb;
 		$data   =   array();
-		$wpdb->query("
+		$wpdb->query($wpdb->prepare("
 		  SELECT `meta_key`, `meta_value`
 			FROM $wpdb->postmeta
-			WHERE `post_id` = ".mysql_real_escape_string($wp_lead_id)."
-		");
+			WHERE `post_id` = %d", $wp_lead_id
+		));
 
 		foreach($wpdb->last_result as $k => $v) {
 			$data[$v->meta_key] =   $v->meta_value;


### PR DESCRIPTION
The call to `mysql_real_escape_string` can fail because it tries to initiate a new database connection (with missing credentials) instead of using the one that the wpdb object created.

To prevent situations like this one, the other `mysql_...` calls in the code should also be replaced with the appropriate method calls on the `$wpdb` global.